### PR TITLE
Dynamic filesize validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ class User < ApplicationRecord
 end
 ```
 
+### Options
+
+You can pass some options to direct_uploader method:
+
+```rb
+direct_uploader :avatar, file_type: %w{jpeg jpg gif png}, max_file_size: 10.megabytes
+```
+
+You can also set max_file_size dynamically using a lambda:
+
+```rb
+direct_uploader :avatar, max_file_size: ->(model) { model.admin? ? 10.megabytes : 5.megabytes }
+```
+
 ## Testing
 While `direct_uploader`'s purpose is only to manage files on a S3 Storage, it ships with a basic file adapter so your tests do not call any external service.
 Add this somewhere in your tests support files :

--- a/lib/direct_uploader/view_helpers.rb
+++ b/lib/direct_uploader/view_helpers.rb
@@ -9,8 +9,14 @@ module DirectUploader
                'host'      => URI.parse(presigned_post[:url]).host
       }
       if object.direct_uploader_field_options[field][:max_file_size].present?
-        data['max_file_size'] = object.direct_uploader_field_options[field][:max_file_size]
+        validation = object.direct_uploader_field_options[field][:max_file_size]
+        if validation.kind_of? Proc
+          data['max_file_size'] = object.direct_uploader_field_options[field][:max_file_size].call(object)
+        else
+          data['max_file_size'] = object.direct_uploader_field_options[field][:max_file_size]
+        end
       end
+
       if object.direct_uploader_field_options[field][:file_type].present?
         data['file_type'] = Array(object.direct_uploader_field_options[field][:file_type]).join("|")
       end


### PR DESCRIPTION
This PR allows dynamic file size validation depending on the model instance itself. See README for more details